### PR TITLE
Add wascc:logging as a well-known capability type

### DIFF
--- a/src/bin/wascap.rs
+++ b/src/bin/wascap.rs
@@ -143,6 +143,9 @@ struct ActorMetadata {
     /// Enable access to the extras functionality (random nos, guids, etc)
     #[structopt(short = "z", long = "extras")]
     extras: bool,
+    /// Enable access to logging capability
+    #[structopt(short = "l", long = "logging")]
+    logging: bool,
     /// Enable access to an append-only event stream provider
     #[structopt(short = "e", long = "events")]
     eventstream: bool,
@@ -256,6 +259,9 @@ fn generate_actor(actor: &ActorMetadata) -> Result<(), Box<dyn ::std::error::Err
     if actor.blob_store {
         caps_list.push(wascap::caps::BLOB.to_string());
     }
+    if actor.logging {
+        caps_list.push(wascap::caps::LOGGING.to_string());
+    }
     if actor.eventstream {        
         caps_list.push(wascap::caps::EVENTSTREAMS.to_string());
     }
@@ -362,6 +368,9 @@ fn sign_file(cmd: &SignCommand) -> Result<(), Box<dyn ::std::error::Error>> {
     }
     if cmd.metadata.blob_store {
         caps_list.push(wascap::caps::BLOB.to_string());
+    }
+    if cmd.metadata.logging {
+        caps_list.push(wascap::caps::LOGGING.to_string());
     }
     if cmd.metadata.extras {
         caps_list.push(wascap::caps::EXTRAS.to_string());

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -20,6 +20,7 @@ pub const HTTP_CLIENT: &str = "wascc:http_client";
 pub const BLOB: &str = "wascc:blobstore";
 pub const EVENTSTREAMS: &str = "wascc:eventstreams";
 pub const EXTRAS: &str = "wascc:extras";
+pub const LOGGING: &str = "wascc:logging";
 
 use std::collections::HashMap;
 
@@ -33,6 +34,7 @@ lazy_static! {
         m.insert(BLOB, "Blob Store");
         m.insert(EVENTSTREAMS, "Event Streams");
         m.insert(EXTRAS, "Extras");
+        m.insert(LOGGING, "Logging");
         m
     };
 }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -513,7 +513,7 @@ impl Operator {
 #[cfg(test)]
 mod test {
     use super::{Account, Actor, Claims, KeyPair, Operator};
-    use crate::caps::{KEY_VALUE, MESSAGING};
+    use crate::caps::{KEY_VALUE, MESSAGING, LOGGING};
     use crate::jwt::since_the_epoch;
     use crate::jwt::validate_token;
 
@@ -694,6 +694,33 @@ mod test {
         assert_eq!(claims, decoded);
     }
 
+    #[test]
+    fn encode_decode_logging_roundtrip() {
+        let kp = KeyPair::new_account();
+        let claims = Claims {
+            metadata: Some(Actor::new(
+                "test".to_string(),
+                Some(vec![MESSAGING.to_string(), LOGGING.to_string()]),
+                Some(vec![]),
+                false,
+                Some(1),
+                Some("".to_string()),
+            )),
+            expires: None,
+            id: nuid::next(),
+            issued_at: 0,
+            issuer: kp.public_key(),
+            subject: "test.wasm".to_string(),
+            not_before: None,
+        };
+
+        let encoded = claims.encode(&kp).unwrap();
+
+        let decoded = Claims::decode(&encoded).unwrap();
+        assert!(validate_token::<Actor>(&encoded).is_ok());
+
+        assert_eq!(claims, decoded);
+    }
     #[test]
     fn account_extra_signers() {
         let op = KeyPair::new_operator();


### PR DESCRIPTION
This changes adds `wascc:logging` as a well-known capability type, to prepare for changes in wascc-host and wascc-actor.

Fixes #12 