### PR TITLE
check jwt segment count

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -176,7 +176,9 @@ where
     pub fn decode(input: &str) -> Result<Claims<T>> {
         let segments: Vec<&str> = input.split('.').collect();
         if segments.len() != 3 {
-            return Err(errors::new(errors::ErrorKind::Token(input.into())));
+            return Err(errors::new(errors::ErrorKind::Token(
+                "invalid token format".into(),
+            )));
         }
         let claims: Claims<T> = from_jwt_segment(segments[1])?;
 
@@ -768,7 +770,7 @@ mod test {
         assert!(decoded.is_err());
         if let Err(e) = decoded {
             match e.kind() {
-                ErrorKind::Token(s) => assert_eq!(s, &encoded_nosep),
+                ErrorKind::Token(s) => assert_eq!(s, "invalid token format"),
                 _ => {
                     panic!("failed to assert errors::ErrorKind::Token");
                 }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -175,6 +175,9 @@ where
 
     pub fn decode(input: &str) -> Result<Claims<T>> {
         let segments: Vec<&str> = input.split('.').collect();
+        if segments.len() != 3 {
+            return Err(errors::new(errors::ErrorKind::Token(input.into())));
+        }
         let claims: Claims<T> = from_jwt_segment(segments[1])?;
 
         Ok(claims)
@@ -512,8 +515,8 @@ impl Operator {
 
 #[cfg(test)]
 mod test {
-    use super::{Account, Actor, Claims, KeyPair, Operator};
-    use crate::caps::{KEY_VALUE, MESSAGING, LOGGING};
+    use super::{Account, Actor, Claims, ErrorKind, KeyPair, Operator};
+    use crate::caps::{KEY_VALUE, LOGGING, MESSAGING};
     use crate::jwt::since_the_epoch;
     use crate::jwt::validate_token;
 
@@ -737,5 +740,39 @@ mod test {
         assert!(validate_token::<Account>(&encoded).is_ok());
         assert_eq!(claims, decoded);
         assert_eq!(claims.metadata.unwrap().valid_signers.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn encode_decode_bad_token() {
+        let kp = KeyPair::new_account();
+        let claims = Claims {
+            metadata: Some(Actor::new(
+                "test".to_string(),
+                Some(vec![MESSAGING.to_string(), KEY_VALUE.to_string()]),
+                Some(vec![]),
+                false,
+                Some(1),
+                Some("".to_string()),
+            )),
+            expires: None,
+            id: nuid::next(),
+            issued_at: 0,
+            issuer: kp.public_key(),
+            subject: "test.wasm".to_string(),
+            not_before: None,
+        };
+
+        let encoded_nosep = claims.encode(&kp).unwrap().replace(".", "");
+
+        let decoded = Claims::<Account>::decode(&encoded_nosep);
+        assert!(decoded.is_err());
+        if let Err(e) = decoded {
+            match e.kind() {
+                ErrorKind::Token(s) => assert_eq!(s, &encoded_nosep),
+                _ => {
+                    panic!("failed to assert errors::ErrorKind::Token");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds a fix and a test for #11 - though I'm not sure it's implemented in the best place. The same check added in `validate_token<T>` introduced a stack overflow after I included the `validate_token(input)?;` inside `decode`. Didn't have time to step through the function calls to see where/why.