### PR TITLE
Ensure a token contains both issuer and subject claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,8 @@ pub enum ErrorKind {
     ExpiredToken,
     TokenTooEarly,
     InvalidAlgorithm,
+    MissingIssuer,
+    MissingSubject,
 }
 
 impl Error {
@@ -64,6 +66,8 @@ impl StdError for Error {
             ErrorKind::ExpiredToken => "Token has expired",
             ErrorKind::TokenTooEarly => "Token cannot be used yet",
             ErrorKind::InvalidAlgorithm => "Invalid JWT algorithm",
+            ErrorKind::MissingIssuer => "Missing issuer claim",
+            ErrorKind::MissingSubject=> "Missing sub claim",
         }
     }
 
@@ -81,6 +85,8 @@ impl StdError for Error {
             ErrorKind::ExpiredToken => None,
             ErrorKind::TokenTooEarly => None,
             ErrorKind::InvalidAlgorithm => None,
+            ErrorKind::MissingIssuer => None,
+            ErrorKind::MissingSubject => None,
         }
     }
 }
@@ -101,6 +107,12 @@ impl fmt::Display for Error {
             ErrorKind::TokenTooEarly => write!(f, "Module cannot be used yet"),
             ErrorKind::InvalidAlgorithm => {
                 write!(f, "Invalid JWT algorithm. WASCAP only supports Ed25519")
+            }
+            ErrorKind::MissingIssuer => {
+                write!(f, "Invalid JWT. WASCAP requires an issuer claim to be present")
+            },
+            ErrorKind::MissingSubject => {
+                write!(f, "Invalid JWT. WASCAP requires a sub claim to be present")
             }
         }
     }


### PR DESCRIPTION
This adds a check to wascap for validating that a token has both `iss`
and `sub` claims when validating the token. If either are missing then
return an error indicating which one is missing.

Closes #17.