### PR TITLE
Updated logging and extras to OTP builtin/logging contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascap"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Wascap - WebAssembly Standard Capabilities. Library for extracting, embedding, and validating claims"

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,12 +1,12 @@
 //! A set of standard names for capabilities that can be provided by a host
-pub const MESSAGING: &str = "wasmcloud:messaging";
-pub const KEY_VALUE: &str = "wasmcloud:keyvalue";
-pub const HTTP_SERVER: &str = "wasmcloud:httpserver";
-pub const HTTP_CLIENT: &str = "wasmcloud:httpclient";
 pub const BLOB: &str = "wasmcloud:blobstore";
+pub const HTTP_CLIENT: &str = "wasmcloud:httpclient";
+pub const HTTP_SERVER: &str = "wasmcloud:httpserver";
+pub const KEY_VALUE: &str = "wasmcloud:keyvalue";
+pub const MESSAGING: &str = "wasmcloud:messaging";
 pub const EVENTSTREAMS: &str = "wasmcloud:eventstreams";
-pub const EXTRAS: &str = "wasmcloud:extras";
-pub const LOGGING: &str = "wasmcloud:logging";
+pub const EXTRAS: &str = "wasmcloud:builtin:extras";
+pub const LOGGING: &str = "wasmcloud:builtin:logging";
 
 use std::collections::HashMap;
 

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -5,7 +5,7 @@ pub const HTTP_SERVER: &str = "wasmcloud:httpserver";
 pub const KEY_VALUE: &str = "wasmcloud:keyvalue";
 pub const MESSAGING: &str = "wasmcloud:messaging";
 pub const EVENTSTREAMS: &str = "wasmcloud:eventstreams";
-pub const EXTRAS: &str = "wasmcloud:builtin:extras";
+pub const NUMBERGEN: &str = "wasmcloud:builtin:numbergen";
 pub const LOGGING: &str = "wasmcloud:builtin:logging";
 
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ lazy_static! {
         m.insert(HTTP_CLIENT, "HTTP Client");
         m.insert(BLOB, "Blob Store");
         m.insert(EVENTSTREAMS, "Event Streams");
-        m.insert(EXTRAS, "Extras");
+        m.insert(NUMBERGEN, "Number Generation");
         m.insert(LOGGING, "Logging");
         m
     };


### PR DESCRIPTION
In the wasmCloud OTP host, `logging` and `extras` will be accessed over the following contracts:
- `wasmcloud:builtin:logging`
- `wasmcloud:builtin:numbergen`

This PR bumps `wascap` a minor version to `0.7.0` to indicate a breaking change.