### PR TITLE
Removes dependency on no longer maintained parity-wasm crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wascap"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
-description = "Wascap - WebAssembly Standard Capabilities. Library for extracting, embedding, and validating claims"
+description = "Wascap - wasmCloud Capabilities. Library for extracting, embedding, and validating claims"
 license = "Apache-2.0"
 homepage = "https://wasmcloud.com"
 documentation = "https://docs.rs/wascap"
@@ -13,14 +13,16 @@ categories = ["cryptography", "authentication", "wasm"]
 
 [dependencies]
 log = "0.4.14"
-env_logger = "0.8.2"
+env_logger = "0.9.3"
 serde_derive = "1.0.123"
 serde = "1.0.123"
 nkeys = "0.2.0"
 base64 = "0.13.0"
 serde_json = "1.0.61"
-nuid = "0.3.0"
-parity-wasm = "0.42.1"
+nuid = "0.4.1"
+wasmparser = "0.94.0"
+wasm-gen = "0.1.4"
+wasm-encoder = "0.19.1"
 lazy_static = "1.4.0"
 ring = "0.16.20"
 data-encoding = "2.3.2"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 ![Rust](https://github.com/wasmcloud/wascap/workflows/Rust/badge.svg)&nbsp;
 ![license](https://img.shields.io/crates/l/wascap.svg)
 
-# ⚠️ Compatibility Warning
-Hashes computed and embedded into `.wasm` modules using a version of wascap < `0.9.0` are **_not_** compatible with the hashes computed by version `0.9.0` and up. In other words, if you have modules that were signed by the "old" wascap and you want them to work going forward, you'll need to re-sign them with 0.9.0.
-
-This compatibility error will show up as a validation failure when a wasmCloud host attempts to load an actor.
+# ℹ️ Compatibility Information
+The hashes computed with v`0.9.0` and later of wascap are not compatible with the hashes signed by prior versions. As a result, modules signed with older versions of wascap will _not_ have their module hashes validated (they'll be ignored). Once the module has been signed with `0.9.0` or greater, it will go back to having its module hash verified.
 
 # wasmCloud Capabilities
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 ![Rust](https://github.com/wasmcloud/wascap/workflows/Rust/badge.svg)&nbsp;
 ![license](https://img.shields.io/crates/l/wascap.svg)
 
-# WASCAP
+# ⚠️ Compatibility Warning
+Hashes computed and embedded into `.wasm` modules using a version of wascap < `0.9.0` are **_not_** compatible with the hashes computed by version `0.9.0` and up. In other words, if you have modules that were signed by the "old" wascap and you want them to work going forward, you'll need to re-sign them with 0.9.0.
+
+This compatibility error will show up as a validation failure when a wasmCloud host attempts to load an actor.
+
+# wasmCloud Capabilities
 
 In the [wasmCloud](https://wasmcloud.dev) host runtime, each actor securely declares the set of capabilities it requires. This library is used to embed, extract, and validate JSON Web Tokens (JWT) containing these capability attestations, as well as the hash of the `wasm` file and a provable issuer for verifying module provenance.
 
@@ -49,28 +54,17 @@ The `Ed25519` key functionality is provided by the [nkeys](https://docs.rs/nkeys
 The `wash` CLI allows you to examine and sign WebAssembly files from a terminal prompt:
 
 ```terminal
- $ wash claims inspect examples/signed_loop.wasm
- ╔════════════════════════════════════════════════════════════════════════╗
- ║                          Secure Actor - Module                         ║
- ╠═════════════╦══════════════════════════════════════════════════════════╣
- ║ Account     ║ ACCHS57D3P2VEON5MQCJM4YA34GYBDFZR3IBG5EQNUONIHBO5X4NIURC ║
- ╠═════════════╬══════════════════════════════════════════════════════════╣
- ║ Module      ║ MBQ2RC3BARXFWTBFW5UJ6J3QSAVYJ7D64Z5LRCPR3UI44F65Q3OMNGYM ║
- ╠═════════════╬══════════════════════════════════════════════════════════╣
- ║ Expires     ║                                                    never ║
- ╠═════════════╬══════════════════════════════════════════════════════════╣
- ║ Can Be Used ║                                              immediately ║
- ╠═════════════╬══════════════════════════════════════════════════════════╣
- ║ Version     ║                                                1.0.0 (0) ║
- ╠═════════════╩══════════════════════════════════════════════════════════╣
- ║                              Capabilities                              ║
- ╠════════════════════════════════════════════════════════════════════════╣
- ║ K/V Store                                                              ║
- ║ Messaging                                                              ║
- ║ HTTP Client                                                            ║
- ║ HTTP Server                                                            ║
- ╠════════════════════════════════════════════════════════════════════════╣
- ║                                  Tags                                  ║
- ╠════════════════════════════════════════════════════════════════════════╣
- ║ None                                                                   ║
- ╚════════════════════════════════════════════════════════════════════════╝
+ $ wash claims inspect echo_s.wasm
+
+                               Echo - Module
+  Account       ACM7TOENKEIO6Q6J66FX53AKXRHH6TH2WZ6K6SZQULNSWLDUIQHSRRSS
+  Module        MC2N2ERC4J7GGMVEMH2TYY73YXYZT2BJK2VGFNYWV26K3KOSVALIFUIB
+  Expires                                                          never
+  Can Be Used                                                immediately
+  Version                                                       None (0)
+  Call Alias                                                   (Not set)
+                               Capabilities
+  HTTP Server
+                                   Tags
+  None
+```

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -175,9 +175,9 @@ pub struct Claims<T> {
     #[serde(rename = "wascap", skip_serializing_if = "Option::is_none")]
     pub metadata: Option<T>,
 
-    /// Revision/version number for wascap to allow for compatibility checks
+    /// Internal revision number used to aid in parsing and validating claims
     #[serde(rename = "wascap_revision", skip_serializing_if = "Option::is_none")]
-    pub wascap_revision: Option<u32>,
+    pub(crate) wascap_revision: Option<u32>,
 }
 
 /// The result of the validation process perform on a JWT

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -12,6 +12,12 @@ use std::{
 const HEADER_TYPE: &str = "jwt";
 const HEADER_ALGORITHM: &str = "Ed25519";
 
+// Current internal revision number that will go into embedded claims
+pub(crate) const WASCAP_INTERNAL_REVISION: u32 = 2;
+
+// Minimum revision number at which we verify module hashes
+pub(crate) const MIN_WASCAP_INTERNAL_REVISION: u32 = 2;
+
 /// A structure containing a JWT and its associated decoded claims
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Token<T> {
@@ -168,6 +174,10 @@ pub struct Claims<T> {
     /// Custom jwt claims in the `wascap` namespace
     #[serde(rename = "wascap", skip_serializing_if = "Option::is_none")]
     pub metadata: Option<T>,
+
+    /// Revision/version number for wascap to allow for compatibility checks
+    #[serde(rename = "wascap_revision", skip_serializing_if = "Option::is_none")]
+    pub wascap_revision: Option<u32>,
 }
 
 /// The result of the validation process perform on a JWT
@@ -305,6 +315,7 @@ impl Claims<Account> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -354,6 +365,7 @@ impl Claims<CapabilityProvider> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -387,6 +399,7 @@ impl Claims<Operator> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -420,6 +433,7 @@ impl Claims<Cluster> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -464,6 +478,7 @@ impl Claims<Actor> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -500,6 +515,7 @@ impl Claims<Invocation> {
             issuer,
             subject,
             not_before,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         }
     }
 }
@@ -788,7 +804,10 @@ mod test {
     use super::{Account, Actor, Claims, ErrorKind, Invocation, KeyPair, Operator};
     use crate::{
         caps::{KEY_VALUE, LOGGING, MESSAGING},
-        jwt::{since_the_epoch, validate_token, CapabilityProvider, ClaimsBuilder, Cluster},
+        jwt::{
+            since_the_epoch, validate_token, CapabilityProvider, ClaimsBuilder, Cluster,
+            WASCAP_INTERNAL_REVISION,
+        },
     };
     use std::collections::HashMap;
 
@@ -811,6 +830,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: Some(since_the_epoch().as_secs() + 1000),
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -842,6 +862,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -865,6 +886,7 @@ mod test {
             issuer: issuer.public_key(),
             subject: "foo".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
         let encoded = claims.encode(&issuer).unwrap();
         let vres = validate_token::<Account>(&encoded);
@@ -891,6 +913,7 @@ mod test {
             issued_at: 0,
             issuer: issuer.public_key(),
             subject: "invocation1".to_string(),
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
         let encoded = claims.encode(&issuer).unwrap();
         let vres = validate_token::<Invocation>(&encoded);
@@ -921,6 +944,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -939,6 +963,7 @@ mod test {
             issuer: "foo".to_string(),
             subject: "test".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
         let encoded = claims.encode(&issuer).unwrap();
         let decoded = Claims::<Actor>::decode(&encoded);
@@ -964,6 +989,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
         let encoded = claims.encode(&kp).unwrap();
         let decoded = Claims::<Operator>::decode(&encoded);
@@ -990,6 +1016,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -1054,6 +1081,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -1118,6 +1146,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded_nosep = claims.encode(&kp).unwrap().replace(".", "");
@@ -1153,6 +1182,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         let encoded = claims.encode(&kp).unwrap();
@@ -1190,6 +1220,7 @@ mod test {
             issuer: kp.public_key(),
             subject: "test.wasm".to_string(),
             not_before: None,
+            wascap_revision: Some(WASCAP_INTERNAL_REVISION),
         };
 
         claims.subject = String::new();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,11 +7,6 @@ use crate::{
 };
 use data_encoding::HEXUPPER;
 use nkeys::KeyPair;
-// use parity_wasm::{
-//     deserialize_buffer,
-//     elements::{CustomSection, Module, Serialize},
-//     serialize,
-// };
 use ring::digest::{Context, Digest, SHA256};
 use std::{
     io::{Read, Write},


### PR DESCRIPTION
* The `parity-wasm` crate is no longer maintained, so relying on it is a liability
* The `parity-wasm` crate, even the newest version, fails to parse "modern" WASI modules produced by TinyGo and other languages (the infamous "unknown opcode" error). In order to ensure we can properly parse newer WASI modules, we need to remove the dependency on parity-wasm.

Instead, the parser is now a crate provided by the bytecode alliance.

wasmCloud modules signed prior to this version of wascap will have their module hashes given a free pass. It's not a breaking change, and the module hash validation comes back as soon as people sign modules with 0.9.0 or greater.