### PR TITLE
fix: minor addition to test

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -174,6 +174,7 @@ fn compute_hash_without_jwt(modbytes: &[u8]) -> Result<String> {
 mod test {
     use super::*;
     use crate::{
+        caps::capability_name,
         caps::{KEY_VALUE, LOGGING, MESSAGING},
         jwt::{Actor, Claims, WASCAP_INTERNAL_REVISION},
     };
@@ -237,12 +238,12 @@ mod test {
         let claims = Claims {
             metadata: Some(Actor::new(
                 "testing".to_string(),
-                Some(vec![MESSAGING.to_string(), LOGGING.to_string()]),
+                Some(vec![capability_name(MESSAGING), capability_name(LOGGING)]),
                 Some(vec![]),
                 false,
                 Some(1),
                 Some("".to_string()),
-                None,
+                Some("somealias".to_string()),
             )),
             expires: None,
             id: nuid::next(),
@@ -260,6 +261,12 @@ mod test {
         if let Some(token) = extract_claims(&modified_bytecode).unwrap() {
             assert_eq!(claims.issuer, token.claims.issuer);
             assert_eq!(claims.subject, token.claims.subject);
+
+            let claims_met = claims.metadata.as_ref().unwrap();
+            let token_met = token.claims.metadata.as_ref().unwrap();
+
+            assert_eq!(claims_met.caps, token_met.caps);
+            assert_eq!(claims_met.call_alias, token_met.call_alias);
         } else {
             unreachable!()
         }


### PR DESCRIPTION
While investigating diffs in wasmCloud/wash#361
I wanted to see assertions for a roundtrip of call_alias
and the human friendly capability name.

NOTE: I found it surprising that the capability names are not
normalized, e.g. if I request "Logging", I get "Logging" back.
If I claim "wasmcloud:builtin:logging", I expect
"wasmcloud:builtin:logging".