### PR TITLE
also remove old JWT section when removing custom section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascap"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["wasmCloud Team"]
 edition = "2018"
 description = "Wascap - wasmCloud Capabilities. Library for extracting, embedding, and validating claims"

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -13,7 +13,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 const SECS_PER_DAY: u64 = 86400;
-const SECTION_JWT: &str = "jwt";
+const SECTION_JWT: &str = "jwt"; // Versions of wascap prior to 0.9 used this section
 const SECTION_WC_JWT: &str = "wasmcloud_jwt";
 
 /// Extracts a set of claims from the raw bytes of a WebAssembly module. In the case where no
@@ -112,6 +112,7 @@ pub fn sign_buffer_with_claims(
 pub(crate) fn strip_custom_section(buf: &[u8]) -> Result<Vec<u8>> {
     let mut m = walrus::Module::from_buffer(buf)
         .map_err(|e| errors::new(ErrorKind::WasmElement(e.to_string())))?;
+    m.customs.remove_raw(SECTION_JWT);
     m.customs.remove_raw(SECTION_WC_JWT);
 
     Ok(m.emit_wasm())


### PR DESCRIPTION
This fixes an issue @ricochet found where, after re-signing a module signed by wascap < v0.9, wash wouldn't report a newly-signed call alias. It turns out we weren't removing the old custom section when re-signing, so when wash extracts claims from the updated module, there's a chance it finds and reads from the old section and ignores the new section. This change removes both the old and new sections, if either exists. After compiling wash with this change, wash correctly reported the newly-signed information.

Signed-off-by: Connor Smith <connor@cosmonic.com>