### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/wascap.yml
+++ b/.github/workflows/wascap.yml
@@ -20,7 +20,7 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - id: rust-check-action
       uses: wasmcloud/common-actions/rust-check@main
       with:
@@ -33,12 +33,11 @@ jobs:
     steps:
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        name: Release ${{ github.ref }}
         draft: false
         prerelease: true
 
@@ -47,7 +46,7 @@ jobs:
     needs: github_release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - id: crates-release-action
         uses: wasmcloud/common-actions/crates-release@main
         with:


### PR DESCRIPTION
https://github.com/softprops/action-gh-release is a replacement for https://github.com/actions/create-release, which has been archived for a few years